### PR TITLE
Add sequence breaks for RBMs and other glitches

### DIFF
--- a/ssrando_jim/locations/dungeons.json
+++ b/ssrando_jim/locations/dungeons.json
@@ -50,14 +50,14 @@
             "name": "Beetle Chest",
             "item_count": 1,
             "access_rules": [
-              "skyviewsk:1,ps,sling",
-              "skyviewsk:1,ps,cs",
-              "skyviewsk:1,ps,beetle",
-              "skyviewsk:1,ps,bow",
-              "skyviewsk:1,wds,bombs,sling",
-              "skyviewsk:1,wds,bombs,cs",
-              "skyviewsk:1,wds,bombs,beetle",
-              "skyviewsk:1,wds,bombs,bow"
+              "[skyviewsk:1],ps,sling",
+              "[skyviewsk:1],ps,cs",
+              "[skyviewsk:1],ps,beetle",
+              "[skyviewsk:1],ps,bow",
+              "[skyviewsk:1],wds,bombs,sling",
+              "[skyviewsk:1],wds,bombs,cs",
+              "[skyviewsk:1],wds,bombs,beetle",
+              "[skyviewsk:1],wds,bombs,bow"
             ],
             "visibility_rules": [
               "op_faron,op_dung,$notrace",
@@ -68,8 +68,8 @@
             "name": "Behind Bars in Hub",
             "item_count": 1,
             "access_rules": [
-              "$skyview_first,beetle,skyviewsk:1",
-              "$skyview_first,whip,[beetle],skyviewsk:1"
+              "$skyview_first,slingshot,[beetle],[skyviewsk:1]",
+              "$skyview_first,whip,[beetle],[skyviewsk:1]"
             ],
             "visibility_rules": [
               "op_faron,op_dung,$notrace",
@@ -83,7 +83,7 @@
             "name": "Behind Three Eyes",
             "item_count": 1,
             "access_rules": [
-              "$skyview_first,beetle,skyviewsk:1,ps"
+              "$skyview_first,beetle,[skyviewsk:1],ps"
             ],
             "visibility_rules": [
               "op_faron,op_dung,$notrace",
@@ -94,10 +94,10 @@
             "name": "Near Boss Door",
             "item_count": 1,
             "access_rules": [
-              "$skyview_first,skyviewsk:2,gs,op_hero",
-              "$skyview_first,skyviewsk:2,hook",
-              "$skyview_first,skyviewsk:2,bow",
-              "$skyview_first,skyviewsk:2,ts"
+              "$skyview_first,[skyviewsk:2],gs,op_hero",
+              "$skyview_first,[skyviewsk:2],hook",
+              "$skyview_first,[skyviewsk:2],bow",
+              "$skyview_first,[skyviewsk:2],ts"
             ],
             "visibility_rules": [
               "op_faron,op_dung,$notrace",
@@ -110,10 +110,10 @@
             "name": "Boss Key Chest",
             "item_count": 1,
             "access_rules": [
-              "$skyview_first,skyviewsk:2,gs,op_hero",
-              "$skyview_first,skyviewsk:2,hook",
-              "$skyview_first,skyviewsk:2,bow",
-              "$skyview_first,skyviewsk:2,ts"
+              "$skyview_first,[skyviewsk:2],gs,op_hero",
+              "$skyview_first,[skyviewsk:2],hook",
+              "$skyview_first,[skyviewsk:2],bow",
+              "$skyview_first,[skyviewsk:2],ts"
             ],
             "visibility_rules": [
               "op_faron,op_dung,$notrace",
@@ -126,10 +126,10 @@
             "name": "Skyview Heart Container",
             "item_count": 1,
             "access_rules": [
-              "$skyview_first,skyviewbk,skyviewsk:2,gs,op_hero",
-              "$skyview_first,skyviewbk,skyviewsk:2,hook,ps",
-              "$skyview_first,skyviewbk,skyviewsk:2,bow,ps",
-              "$skyview_first,skyviewbk,skyviewsk:2,ts"
+              "$skyview_first,skyviewbk,[skyviewsk:2],gs,op_hero",
+              "$skyview_first,skyviewbk,[skyviewsk:2],hook,ps",
+              "$skyview_first,skyviewbk,[skyviewsk:2],bow,ps",
+              "$skyview_first,skyviewbk,[skyviewsk:2],ts"
             ],
             "visibility_rules": [
               "op_faron,op_dung,$notrace",
@@ -153,10 +153,10 @@
         "parent": "Skyview Temple",
         "color": "006400",
         "access_rules": [
-          "$skyview_first,skyviewbk,skyviewsk:2,gs,op_hero",
-          "$skyview_first,skyviewbk,skyviewsk:2,gs,hb",
-          "$skyview_first,skyviewbk,skyviewsk:2,gs,bow",
-          "$skyview_first,skyviewbk,skyviewsk:2,ts"
+          "$skyview_first,skyviewbk,[skyviewsk:2],gs,op_hero",
+          "$skyview_first,skyviewbk,[skyviewsk:2],gs,hb",
+          "$skyview_first,skyviewbk,[skyviewsk:2],gs,bow",
+          "$skyview_first,skyviewbk,[skyviewsk:2],ts"
         ],
         "sections": [
           {
@@ -260,7 +260,7 @@
             "name": "Lizalfos Chest",
             "item_count": 1,
             "access_rules": [
-              "$earth_bridge,hook",
+              "$earth_bridge,[hook]",
               "$earth_bridge,bombs,beetle"
             ],
             "visibility_rules": [
@@ -274,7 +274,7 @@
             "name": "Boss Key Chest",
             "item_count": 1,
             "access_rules": [
-              "$earth_bridge,hook",
+              "$earth_bridge,[hook]",
               "$earth_bridge,bombs,beetle,mitts"
             ],
             "visibility_rules": [
@@ -288,8 +288,8 @@
             "name": "Earth Heart Container",
             "item_count": 1,
             "access_rules": [
-              "bombs,hook,earthbk,ps",
-              "bombs,beetle,mitts,earthbk,ps"
+              "[bombs],[hook],earthbk,ps",
+              "[bombs],[beetle],[mitts],earthbk,ps"
             ],
             "visibility_rules": [
               "op_eldin,op_dung,$notrace",
@@ -312,7 +312,7 @@
         "name": "Earth Spring",
         "parent": "Earth Temple",
         "access_rules": [
-          "bombs,hook,earthbk,gs",
+          "[bombs],[hook],earthbk,gs",
           "bombs,beetle,mitts,earthbk,gs"
         ],
         "color": "#dc143c",
@@ -541,6 +541,7 @@
             "name": "Whip",
             "item_count": 1,
             "access_rules": [
+	      "[cisternsk:2],[ps],wds",
               "cisternsk:1,[cisternsk:2],ps",
               "cisternsk:1,[cisternsk:2],$cistern_statue"
             ],
@@ -605,7 +606,7 @@
             "item_count": 1,
             "access_rules": [
               "$cistern_statue,cs",
-              "$cistern_statue,hook"
+	      "$cistern_statue,[hook]"
             ],
             "visibility_rules": [
               "op_faron,op_dung,$notrace",
@@ -850,7 +851,7 @@
             "name": "Sanc Bottle",
             "item_count": 1,
             "access_rules": [
-              "$sanc_pods,sancsk:1,mogma,ps"
+              "[$sanc_pods],[sancsk:1],[mogma],ps"
             ],
             "visibility_rules": [
               "op_eldin,op_dung,$notrace",
@@ -861,7 +862,8 @@
             "name": "Map Chest",
             "item_count": 1,
             "access_rules": [
-              "hook,cs,sancsk:2,mogma,bellows,ps"
+              "hook,[cs],sancsk:2,mogma,bellows,ps",
+	      "$sanc_pods,[hook],[cs],[sancsk:2],[mogma],[bellows],ps"
             ],
             "visibility_rules": [
               "op_eldin,op_dung,$notrace",
@@ -872,7 +874,8 @@
             "name": "Third Small Key",
             "item_count": 1,
             "access_rules": [
-              "hook,cs,sancsk:2,mogma,bellows,bombs,ps"
+              "hook,[cs],sancsk:2,mogma,bellows,bombs,ps",
+	      "$sanc_pods,mogma,bombs,ps,[hook],[cs],[sancsk:2],[bellows]"
             ],
             "visibility_rules": [
               "op_eldin,op_dung,$notrace",
@@ -883,7 +886,8 @@
             "name": "Plats Chest",
             "item_count": 1,
             "access_rules": [
-              "hook,sancsk:3,mogma,ps"
+              "hook,sancsk:3,mogma,ps",
+	      "$sanc_pods,[hook],[sancsk:3],[mogma],[ps]"
             ],
             "visibility_rules": [
               "op_eldin,op_dung,$notrace",
@@ -894,7 +898,7 @@
             "name": "Staircase Room",
             "item_count": 1,
             "access_rules": [
-              "hook,cs,sancsk:3,mogma,ps"
+              "[hook],cs,[sancsk:3],[mogma],[ps]",
             ],
             "visibility_rules": [
               "op_eldin,op_dung,$notrace",
@@ -905,7 +909,8 @@
             "name": "Boss Key Chest",
             "item_count": 1,
             "access_rules": [
-              "hook,cs,sancsk:3,mogma,ps"
+              "hook,cs,sancsk:3,mogma,ps",
+	      "$sanc_pods,[hook],[cs],[sancsk:3],[mogma],[ps]"
             ],
             "visibility_rules": [
               "op_eldin,op_dung,$notrace",
@@ -918,7 +923,8 @@
             "name": "Sanctuary Heart Container",
             "item_count": 1,
             "access_rules": [
-              "hook,sancsk:3,mogma,sancbk,ps"
+              "hook,sancsk:3,mogma,sancbk,ps",
+	      "$sanc_pods,sancbk,ps,[hook],[sancsk:3],[mogma]"
             ],
             "visibility_rules": [
               "op_eldin,op_dung,$notrace",
@@ -931,7 +937,8 @@
             "name": "Din's Flame",
             "item_count": 1,
             "access_rules": [
-              "hook,sancsk:3,mogma,sancbk,gs"
+              "hook,sancsk:3,mogma,sancbk,gs",
+	      "$sanc_pods,sancbk,gs,[hook],[sancsk:3],[mogma]"
             ],
             "visibility_rules": [
               "op_eldin,op_dung,$notrace",

--- a/ssrando_jim/locations/overworld.json
+++ b/ssrando_jim/locations/overworld.json
@@ -264,6 +264,9 @@
               {
                 "name": "Lake Floria Boulder Rupee",
                 "item_count": 0,
+		"access_rules": [
+		  "wds"
+		],
                 "visibility_rules": [
                   "op_faron,op_freestand"
                 ],
@@ -273,17 +276,30 @@
               {
                 "name": "Lake Floria Chest",
                 "item_count": 1,
+		"access_rules": [
+		  "wds"
+		],
                 "visibility_rules": [
                   "op_faron,op_misc"
                 ]
               },
               {
-                "name": "Dragon Lair Chests",
-                "item_count": 2,
+                "name": "Dragon Lair First Chest",
+                "item_count": 1,
                 "visibility_rules": [
                   "op_faron,op_misc"
                 ]
               },
+	      {
+		"name": "Dragon Lair Second Chest",
+		"item_count": 1,
+		"access_rules": [
+		  "wds"
+		],
+		"visibility_rules": [
+                  "op_faron,op_misc"
+		]
+	      },
               {
                 "name": "Outside Cistern Rupee",
                 "item_count": 0,
@@ -608,7 +624,8 @@
                 "name": "Digging HP",
                 "item_count": 1,
                 "access_rules": [
-                  "$bottle,mogma"
+                  "$bottle,mogma",
+		  "gust,mogma,[$bottle]"
                 ],
                 "visibility_rules": [
                   "op_eldin,op_freestand"
@@ -713,7 +730,7 @@
                 "name": "End of Mines Chest",
                 "item_count": 1,
                 "access_rules": [
-                  "bomb",
+                  "[bomb]",
                   "hook"
                 ],
                 "visibility_rules": [
@@ -757,7 +774,7 @@
                 "item_count": 1,
                 "access_rules": [
                   "cs",
-                  "bombs",
+                  "[bombs]",
                   "hook"
                 ],
                 "visibility_rules": [
@@ -801,7 +818,7 @@
                 "name": "Chest near Trial",
                 "item_count": 1,
                 "access_rules": [
-                  "$lanayru2,cs"
+                  "$lanayru2,[cs]"
                 ],
                 "visibility_rules": [
                   "op_lanayru,op_misc"
@@ -923,7 +940,7 @@
                 "name": "Shortcut Chest",
                 "item_count": 1,
                 "access_rules": [
-                  "$ampilus"
+                  "[$ampilus]"
                 ],
                 "visibility_rules": [
                   "op_lanayru,op_minid"
@@ -1030,7 +1047,9 @@
                     "access_rules": [
                       "whip,bow",
                       "whip,beetle",
-                      "whip,sling"
+                      "whip,sling",
+		      "[whip],bombs",
+		      "[whip],hook"
                     ],
                     "visibility_rules": [
                       "op_lanayru,op_misc"
@@ -1056,7 +1075,9 @@
                     "access_rules": [
                       "whip,bow",
                       "whip,beetle",
-                      "whip,sling"
+                      "whip,sling",
+		      "[whip],bombs",
+		      "[whip],hook"
                     ],
                     "visibility_rules": [
                       "op_lanayru,op_misc"
@@ -1068,7 +1089,9 @@
                     "access_rules": [
                       "whip,bow,bellows",
                       "whip,beetle,bellows",
-                      "whip,sling,bellows"
+                      "whip,sling,bellows",
+		      "[whip],bombs,bellows",
+		      "[whip],hook,bellows"
                     ],
                     "visibility_rules": [
                       "op_lanayru,op_misc"

--- a/ssrando_jim/scripts/logic.lua
+++ b/ssrando_jim/scripts/logic.lua
@@ -150,7 +150,15 @@ function deepwoods()
 end
 
 function floria()
-  return (faron() and wds() and yerbal() and goddess())
+  if (faron()) then
+    if (wds() and yerbal() and goddess()) then
+      return true
+    elseif (sword()) then
+      return true, AccessibilityLevel.SequenceBreak
+    end
+  else
+    return false
+  end
 end
 
 function eldin1()
@@ -170,7 +178,13 @@ function lanayru1()
 end
 
 function lanayru2()
-  return (lanayru1() and (cs() or hook()))
+  if (lanayru1() and (cs() or hook())) then
+    return true
+  elseif (lanayru1()) then
+    return true, AccessibilityLevel.SequenceBreak
+  else
+    return false
+  end
 end
 
 function sea()
@@ -192,7 +206,13 @@ function skyview_first() -- first room of skyview
 end
 
 function earth_bridge() -- drawbridge in earth
-  return (bow() or (btl() and (lizalfos() or sling() or cs())))
+  if (bow() or (btl() and (lizalfos() or sling() or cs()))) then
+    return true
+  elseif (goddess()) then -- keese yeet
+    return true, AccessibilityLevel.SequenceBreak
+  else
+    return false
+  end
 end
 
 function mine_crystal() -- crystal in map room
@@ -203,6 +223,8 @@ function cistern_statue() -- lower statue
   if (whip() and (cs() or (wds() and (bow() or btl()) and has("cisternsk",2)))) then
     return true
   elseif (whip() and (wds() and (bow() or btl()) and has("cisternsk",1))) then
+    return true, AccessibilityLevel.SequenceBreak
+  elseif (wds() and sword()) then -- cistern clip
     return true, AccessibilityLevel.SequenceBreak
   else 
     return false
@@ -216,8 +238,15 @@ end
 -- dungeon beatable macros
 
 function skyview()
-  return (skyview_acc() and goddess() and has("skyviewsk",2) and has("skyviewbk")
-    and (hero() or hook() or bow() or tms()))
+  if (skyview_acc() and goddess() and has("skyviewsk",2) and has("skyviewbk")
+      and (hero() or hook() or bow() or tms())) then
+    return true
+  elseif (skyview_acc() and goddess() and has("skyviewbk")
+      and (hero() or hook() or bow() or tms())) then
+    return true, AccessibilityLevel.SequenceBreak
+  else
+    return false
+  end
 end
 
 function skyview2()
@@ -344,7 +373,7 @@ function cube_svs() --skyview spring
 end
 
 function cube_fl() --floria
-  return (floria() and goddess())
+  return (floria() and wds() and goddess())
 end
 
 function cube_fw() --floria waterfall
@@ -384,7 +413,13 @@ function cube_sw() --summit waterfall
 end
 
 function cube_fse() --sanc entrance
-  return (volcano() and bottle() and cs()) and goddess()
+  if ((volcano() and bottle() and cs()) and goddess()) then
+    return true
+  elseif ((volcano() and gust() and cs()) and goddess()) then
+    return true, AccessibilityLevel.SequenceBreak
+  else
+    return false
+  end
 end
 
 function cube_lme() --mine entrance
@@ -392,11 +427,19 @@ function cube_lme() --mine entrance
 end
 
 function cube_so() --sand oasis
-  return (lanayru2() and goddess())
+  if (goddess()) then
+    return lanayru2()
+  else
+    return false
+  end
 end
 
 function cube_tot() --ride in tot
-  return (lanayru2() and hook() and goddess())
+  if (hook() and goddess()) then
+    return lanayru2()
+  else
+    return false
+  end
 end
 
 function cube_sp() --desert secret passageway
@@ -404,8 +447,15 @@ function cube_sp() --desert secret passageway
 end
 
 function cube_hbf() --hook beetle flight
-  return (lanayru1() and (cs() or bomb() or hook()) and
-    ((goddess() and (hero() or cs())) or tms()))
+  if (lanayru1() and ((goddess() and (hero() or cs())) or tms())) then
+    if (cs() or bomb() or hook()) then
+      return true
+    else
+      return true, AccessibilityLevel.SequenceBreak
+    end
+  else
+    return false
+  end
 end
 
 function cube_ah() --ancient harbour
@@ -508,7 +558,13 @@ function dungeon_dw() -- dungeon entrance in deep woods
 end
 
 function dungeon_ev() -- dungeon entrance in eldin volcano
-  return (eldin2() and has("kp",5))
+  if (eldin2() and has("kp",5)) then
+    return true
+  elseif (eldin2()) then
+    return true, AccessibilityLevel.SequenceBreak
+  else
+    return false
+  end
 end
 
 function dungeon_ld() -- dungeon entrance in lanayru desert
@@ -516,7 +572,11 @@ function dungeon_ld() -- dungeon entrance in lanayru desert
 end
 
 function dungeon_lf() -- dungeon entrance in lake floria
-  return floria()
+  if (wds()) then
+    return floria()
+  else
+    return false
+  end
 end
 
 function dungeon_ss() -- dungeon entrance in sand sea
@@ -524,7 +584,13 @@ function dungeon_ss() -- dungeon entrance in sand sea
 end
 
 function dungeon_vs() -- dungeon entrance in volcano summit
-  return (volcano() and bottle() and cs())
+  if (volcano() and bottle() and cs()) then
+    return true
+  elseif (volcano() and (bottle() or gust())) then
+    return true, AccessibilityLevel.SequenceBreak -- village windmill + shiekah stone rbms
+  else
+    return false
+  end
 end
 
 function dungeon_sl() -- dungeon entrance in skyloft


### PR DESCRIPTION
This accounts for the following sequence breaks:

 - Precise slingshot shot to hit crystal at top of hub room in Skyview
 - Skyview UA BiTwarp
 - Earth Temple door RBM in Eldin
 - Keese Yeet in Earth Temple
 - Bridge RBM in Earth Temple
 - Brakeslide skips in Lanayru Mines and Lanayru Desert
 - Lanayru Desert UA BiTwarp
 - Fence hop to Lake Floria
 - Cistern clip
 - Peahat RBM in skipper's retreat
 - Volcano Summit flame wall RBMs
 - Fire Sanctuary UA BiTwarps
 - Fire Sanctuary overworld bird statue and shortcut gate RBMs
 - Fire Sanctuary vanilla boss key chest RBMs
 - Fire Sanctuary Plats chest RBM
 - Fire Sanctuary vanilla map chest RBM